### PR TITLE
Create lmdb in windows

### DIFF
--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -4580,9 +4580,13 @@ mdb_env_open(MDB_env *env, const char *path, unsigned int flags, mdb_mode_t mode
 	env->me_fd = CreateFile(dpath, oflags, FILE_SHARE_READ|FILE_SHARE_WRITE,
 		NULL, len, mode, NULL);
 	DWORD dwTemp;
-	if (!DeviceIoControl(env->me_fd, FSCTL_SET_SPARSE, NULL, 0,
-		NULL, 0, &dwTemp, NULL))
-		; // If the file is not sparsed, it will allocate the full environment
+	if (!F_ISSET(flags, MDB_RDONLY)) {
+		if (!DeviceIoControl(env->me_fd, FSCTL_SET_SPARSE, NULL, 0,
+			NULL, 0, &dwTemp, NULL)) {
+				rc = ErrCode();
+				//goto leave;
+			}
+	}
 #else
 	if (F_ISSET(flags, MDB_RDONLY))
 		oflags = O_RDONLY;

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -4579,6 +4579,10 @@ mdb_env_open(MDB_env *env, const char *path, unsigned int flags, mdb_mode_t mode
 	mode = FILE_ATTRIBUTE_NORMAL;
 	env->me_fd = CreateFile(dpath, oflags, FILE_SHARE_READ|FILE_SHARE_WRITE,
 		NULL, len, mode, NULL);
+	DWORD dwTemp;
+	if (!DeviceIoControl(env->me_fd, FSCTL_SET_SPARSE, NULL, 0,
+		NULL, 0, &dwTemp, NULL))
+		; // If the file is not sparsed, it will allocate the full environment
 #else
 	if (F_ISSET(flags, MDB_RDONLY))
 		oflags = O_RDONLY;
@@ -4695,6 +4699,14 @@ mdb_env_close0(MDB_env *env, int excl)
 	if (env->me_map) {
 		munmap(env->me_map, env->me_mapsize);
 	}
+#ifdef _WIN32
+	LARGE_INTEGER liCurrentPosition = { 1024*1024 };//add 1MB free space
+	SetFilePointerEx(env->me_fd, liCurrentPosition,
+		&liCurrentPosition, FILE_CURRENT);
+	//printf("current pointer:%ld", liCurrentPosition.LowPart);
+	if (!SetEndOfFile(env->me_fd))
+		printf("set end of file error!\n");
+#endif
 	if (env->me_mfd != env->me_fd && env->me_mfd != INVALID_HANDLE_VALUE)
 		(void) close(env->me_mfd);
 	if (env->me_fd != INVALID_HANDLE_VALUE)


### PR DESCRIPTION
Now it is able to create lmdb in windows by setting the created files as sparse file. However, this feature is only supported by NTFS file system. It would create a very big file (say 1TB in caffe), but ocuppies a little disk spaces. The file size will be truncated when calling `mdb_env_close` function.

I have tested it on MNIST, everything works well.
